### PR TITLE
Improves compatibility with some Android apps

### DIFF
--- a/UPnP/UPnPDevice.cs
+++ b/UPnP/UPnPDevice.cs
@@ -1502,7 +1502,14 @@ namespace OpenSource.UPnP
                 msg.AddTag("Server", "Windows NT/5.0, UPnP/1.0");
                 msg.AddTag("EXT", "");
                 msg.AddTag("Cache-Control", "max-age=" + ExpirationTimeout.ToString());
-                msg.AddTag("ST", st);
+                if (ST == "upnp:rootdevice")
+                {
+                    msg.AddTag("ST", "upnp:rootdevice");
+                }
+                else
+                {
+                    msg.AddTag("ST", DeviceURN);
+                }
                 msg.AddTag("USN", "uuid:" + UniqueDeviceName + "::" + st);
                 if (UserAgentTag != null)
                 {

--- a/UPnP/UPnPService.cs
+++ b/UPnP/UPnPService.cs
@@ -3712,23 +3712,29 @@ namespace OpenSource.UPnP
                 }
             }
 
-            foreach (UPnPArgument _ARG in VarList)
-            {
-                UPnPStateVariable V = this.GetStateVariableObject(MethodName, _ARG.Name);
-                try
-                {
-                    V.Validate(UPnPService.CreateObjectInstance(V.GetNetType(), (string)_ARG.DataValue));
-                }
-                catch (Exception ex)
-                {
-                    throw (new UPnPCustomException(402, "Argument [" + _ARG.Name + "] : " + ex.Message));
-                }
-            }
-
             UPnPAction A = this.GetAction(MethodName);
             if (A == null)
             {
                 throw (new UPnPCustomException(401, "Invalid Action: " + MethodName));
+            }
+
+            for (int i = VarList.Count - 1; i >= 0; i--)
+            {
+                UPnPStateVariable V = this.GetStateVariableObject(MethodName, ((UPnPArgument)VarList[i]).Name);
+                if (V == null)
+                {
+                  VarList.RemoveAt(i);
+                  continue;
+                }
+
+                try
+                {
+                    V.Validate(UPnPService.CreateObjectInstance(V.GetNetType(), (string)((UPnPArgument)VarList[i]).DataValue));
+                }
+                catch (Exception ex)
+                {
+                    throw (new UPnPCustomException(402, "Argument [" + ((UPnPArgument)VarList[i]).Name + "] : " + ex.Message));
+                }
             }
 
             if (A.SpecialCase != null)


### PR DESCRIPTION
1.     "upnp:rootdevice"  is expected in M-SEARCH response.

From UPnP spec.   "1.3.3 Search response"
```text
ST

  Required. Field value contains Search Target. Single URI. The response sent by the device depends on the
  field value of the ST header field that was sent in the request. In some cases, the device shall send multiple
  response messages as follows. If the received ST field value was:

  ssdp:all
    Respond 3+2d+k times for a root device with d embedded devices and s embedded services but only
    k distinct service types (see clause 1.1.2, “SSDP message header fields” for a definition of each
    message to be sent). Field value for ST header field shall be the same as for the NT header field in
    NOTIFY messages with ssdp:alive. (See above.)

  upnp:rootdevice
    Respond once for root device. Shall be upnp:rootdevice.

  uuid:device-UUID
    Respond once for each matching device, root or embedded. Shall be uuid:device-UUID where deviceUUID is specified by the UPnP vendor. See clause 1.1.4, “UUID format and recommended generation
    algorithms” for the MANDATORY UUID format.

  urn:schemas-upnp-org:device:deviceType:ver
    Respond once for each matching device, root or embedded. Shall be
    urn:schemas-upnp-org:device:deviceType:ver where deviceType and ver are defined by UPnP Forum
    working committee and ver shall contain the version of the device type contained in the M-SEARCH
    request.

  urn:schemas-upnp-org:service:serviceType:ver
    Respond once for each matching service type. shall be
    urn:schemas-upnp-org:service:serviceType:ver where serviceType and ver are defined by the UPnP
    Forum working committee and ver shall contain the version of the service type contained in the MSEARCH request.

  urn:domain-name:device:deviceType:ver
    Respond once for each matching device, root or embedded. shall be urn:domainname:device:deviceType:ver where domain-name (a Vendor Domain Name), deviceType and ver are
    defined by the UPnP vendor and ver shall contain the version of the device type from the M-SEARCH
    request. Period characters in the Vendor Domain Name shall be replaced with hyphens in accordance
    with RFC 2141.

  urn:domain-name:service:serviceType:ver
    Respond once for each matching service type. shall be urn: domain-name:service:serviceType:ver
    where domain-name (a Vendor Domain Name), serviceType and ver are defined by the UPnP vendor
    and ver shall contain the version of the service type from the M-SEARCH request. Period characters
    in the Vendor Domain Name shall be replaced with hyphens in accordance with RFC 2141.

```

2.     Some app sends extra parameters which are not defined in UPnP specification. Ignoring these parameters allows it to run normally.